### PR TITLE
ヘッダーの外見を実装

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 export default function Footer() {
   return (
-    <footer className="bottom-0 w-full p-4 bg-black ">
+    <footer className="bottom-0 w-full p-4 bg-black min-h-screen">
       <div className="flex justify-center p-4">
         <Image
           src="/icon/44thlogo.png"

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -9,13 +9,13 @@ export default function Footer(){
                 <Image src="/icon/Instagram_Glyph_White.svg" alt="instagram-link" width={50} height={50}/>
 
             </div>
-            <div className="flex flex-col justify-center p-4">
-            <div className="text-body2 text-gray text-center whitespace-pre-wrap">協賛企業一覧</div>
-            <div className="text-body2 text-gray text-center whitespace-pre-wrap">アンケートリンク</div>
-            <div className="text-body2 text-gray text-center whitespace-pre-wrap">長岡技術科学大学ホームページ</div>
-            <div className="p-2">
-            <div className="text-body2 text-white text-center whitespace-pre-wrap">〒940-2188</div>
-            <div className="text-body2 text-white text-center whitespace-pre-wrap">新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
+            <div className="flex flex-col justify-center p-4 text-body2 text-gray text-center whitespace-pre-wrap">
+            <div>協賛企業一覧</div>
+            <div>アンケートリンク</div>
+            <div>長岡技術科学大学ホームページ</div>
+            <div className="p-2 text-white">
+            <div>〒940-2188</div>
+            <div>新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
             </div>
           </div>
         </footer>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,23 +1,32 @@
 import Image from "next/image";
-export default function Footer(){
-    return(
-        <footer className="bottom-0 w-full p-4 bg-black ">
-           <div className="flex justify-center p-4">
-           <Image src="/icon/44thlogo.png" alt="44th-icon" width={64} height={64} />
-           </div>
-            <div className="flex justify-center gap-[30%] md:gap-[30%] lg:gap-[30%] p-4">
-                <Image src="/icon/Instagram_Glyph_White.svg" alt="instagram-link" width={50} height={50}/>
-
-            </div>
-            <div className="flex flex-col justify-center p-4 text-body2 text-gray text-center whitespace-pre-wrap">
-            <div>協賛企業一覧</div>
-            <div>アンケートリンク</div>
-            <div>長岡技術科学大学ホームページ</div>
-            <div className="p-2 text-white">
-            <div>〒940-2188</div>
-            <div>新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
-            </div>
-          </div>
-        </footer>
-    );
+export default function Footer() {
+  return (
+    <footer className="bottom-0 w-full p-4 bg-black ">
+      <div className="flex justify-center p-4">
+        <Image
+          src="/icon/44thlogo.png"
+          alt="44th-icon"
+          width={64}
+          height={64}
+        />
+      </div>
+      <div className="flex justify-center gap-[30%] md:gap-[30%] lg:gap-[30%] p-4">
+        <Image
+          src="/icon/Instagram_Glyph_White.svg"
+          alt="instagram-link"
+          width={50}
+          height={50}
+        />
+      </div>
+      <div className="flex flex-col justify-center p-4 text-body2 text-gray text-center whitespace-pre-wrap">
+        <div>協賛企業一覧</div>
+        <div>アンケートリンク</div>
+        <div>長岡技術科学大学ホームページ</div>
+        <div className="p-2 text-white">
+          <div>〒940-2188</div>
+          <div>新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,0 +1,21 @@
+import Image from "next/image";
+export default function Footer(){
+    return(
+        <footer className="justify-center p-4 bg-black ">
+           <div className="flex justify-center p-4">
+           <Image src="/icon/44thlogo.png" alt="44th-icon" width={64} height={64} />
+           </div>
+            <div className="flex justify-center gap-[30%] md:gap-[30%] lg:gap-[30%] p-4">
+                <Image src="/icon/Instagram_Glyph_White.svg" alt="instagram-link" width={50} height={50}/>
+
+            </div>
+            <div className="flex flex-col justify-center p-4">
+            <div className="text-body2 text-gray text-center whitespace-pre-wrap">協賛企業一覧</div>
+            <div className="text-body2 text-gray text-center whitespace-pre-wrap">アンケートリンク</div>
+            <div className="text-body2 text-gray text-center whitespace-pre-wrap">長岡技術科学大学ホームページ</div>
+            <div className="text-body2 text-white text-center whitespace-pre-wrap">〒940-2188</div>
+            <div className="text-body2 text-white text-center whitespace-pre-wrap">新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
+            </div>
+        </footer>
+    );
+}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -13,9 +13,11 @@ export default function Footer(){
             <div className="text-body2 text-gray text-center whitespace-pre-wrap">協賛企業一覧</div>
             <div className="text-body2 text-gray text-center whitespace-pre-wrap">アンケートリンク</div>
             <div className="text-body2 text-gray text-center whitespace-pre-wrap">長岡技術科学大学ホームページ</div>
+            <div className="p-2">
             <div className="text-body2 text-white text-center whitespace-pre-wrap">〒940-2188</div>
             <div className="text-body2 text-white text-center whitespace-pre-wrap">新潟県長岡市上富岡町1603-1 長岡技術科学大学</div>
             </div>
+          </div>
         </footer>
     );
 }

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 export default function Footer(){
     return(
-        <footer className="justify-center p-4 bg-black ">
+        <footer className="bottom-0 w-full justify-center p-4 bg-black ">
            <div className="flex justify-center p-4">
            <Image src="/icon/44thlogo.png" alt="44th-icon" width={64} height={64} />
            </div>

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 export default function Footer(){
     return(
-        <footer className="bottom-0 w-full justify-center p-4 bg-black ">
+        <footer className="bottom-0 w-full p-4 bg-black ">
            <div className="flex justify-center p-4">
            <Image src="/icon/44thlogo.png" alt="44th-icon" width={64} height={64} />
            </div>

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 export default function Header() {
     return (
-      <header className="fixed top-0 left-0 w-full bg-black flex justify-between p-4 shadow_button">
+      <header className="fixed top-0 left-0 w-full bg-black flex justify-between pb-4 pt-4 pl-[3%] pr-[3%] shadow_button">
         <div className="flex">
             <Image 
             src="/icon/44thlogo.png"

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,7 +1,7 @@
 import Image from "next/image";
 export default function Header() {
     return (
-      <header className="fixed top-0 left-0 w-full bg-black flex justify-between p-4">
+      <header className="fixed top-0 left-0 w-full bg-black flex justify-between p-4 shadow_button">
         <div className="flex">
             <Image 
             src="/icon/44thlogo.png"

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,0 +1,13 @@
+import Image from "next/image";
+export default function Header() {
+    return (
+      <header className="fixed top-0 left-0 w-full bg-black flex justify-between p-4">
+        <div className="flex">
+            <img src="../public/icon/44thlogo.png" />
+        </div>
+        <div className="flex">
+            <img src="../public/icon/BiMenu.svg" />
+        </div>
+      </header>
+    );
+  }

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -3,10 +3,20 @@ export default function Header() {
     return (
       <header className="fixed top-0 left-0 w-full bg-black flex justify-between p-4">
         <div className="flex">
-            <img src="../public/icon/44thlogo.png" />
+            <Image 
+            src="/icon/44thlogo.png"
+            alt="44th_icon"
+            width={40}
+            height={40}
+            />
         </div>
         <div className="flex">
-            <img src="../public/icon/BiMenu.svg" />
+            <Image 
+            src="/icon/BiMenu.svg"
+            alt="menu"
+            width={32}
+            height={32}
+            />
         </div>
       </header>
     );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import "./globals.css";
 import { newTegomin, notoSansJP } from "./utils/fonts";
 import Header from "./components/header";
+import Footer from "./components/footer";
+
 
 
 export const metadata: Metadata = {
@@ -19,6 +21,7 @@ export default function RootLayout({
       <body className={`bg-[url('/hero_header/hero_header.svg')] bg-cover bg-fixed bg-center min-h-screen  ${notoSansJP.className} ${notoSansJP.variable} ${newTegomin.variable} antialiased`}>
         <Header />
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,8 +19,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`bg-[url('/hero_header/hero_header.svg')] bg-cover bg-fixed bg-center min-h-screen  ${notoSansJP.className} ${notoSansJP.variable} ${newTegomin.variable} antialiased`}>
-        <Header />
+        <Header/>
+        <div className="mt-20">
         {children}
+        </div>
         <Footer />
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { newTegomin, notoSansJP } from "./utils/fonts";
+import Header from "./components/header";
+
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -15,6 +17,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`bg-[url('/hero_header/hero_header.svg')] bg-cover bg-fixed bg-center min-h-screen  ${notoSansJP.className} ${notoSansJP.variable} ${newTegomin.variable} antialiased`}>
+        <Header />
         {children}
       </body>
     </html>

--- a/public/icon/BiMenu.svg
+++ b/public/icon/BiMenu.svg
@@ -1,0 +1,3 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.33325 8H26.6666V10.6667H5.33325V8ZM5.33325 14.6667H26.6666V17.3333H5.33325V14.6667ZM5.33325 21.3333H26.6666V24H5.33325V21.3333Z" fill="#D6BA26"/>
+</svg>


### PR DESCRIPTION
# 対応Issue
resolve #17 #19 

# 概要
headerコンポーネントを編集し、layoutにヘッダーを実装
同じくfooterを実装


# 実装詳細
iconにハンバーガーメニューの画像を追加
headerコンポーネントの編集
layoutにHeaderを実装


# 画面スクリーンショット等
<img width="374" alt="image" src="https://github.com/user-attachments/assets/ed8b11b7-b12e-4dc3-9518-9b0c24355b6d" />
インスタとXが横並びで配置された時のfooterの想定
<img width="347" alt="image" src="https://github.com/user-attachments/assets/874f3a28-781b-4aae-ae21-1d340a2269f4" />




# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] プラウザで実装が確認できているか
- [x] フッターのテキストが画面幅が小さくなった時に折り返されるか
- [x] （Xアイコンが実装された想定で）インスタのアイコンを横並びに配置した際に画面幅を変えても十分な間隔が維持されているかどうか


# 備考
44thロゴがpngなので、ドライブにロゴのsvgがあがったら差し替えます
ヘッダーの幅などはチルオアシス富山を参考にしました。今後調整が発生するかもです
https://dozo-gift.com/a/p/pages/chilloasistoyama/?srsltid=AfmBOopw3jf04OAgepsvt9VA4rr4OiWgZc1Rf8pZz6fxkmknZv3RlGzR

※ブランチを切り忘れてheaderとfooterを同じブランチで開発してしまいました