### PR TITLE
お知らせセクションにスクロールバーを追加

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -7,7 +7,6 @@
   --foreground: #171717;
   --font-noto-sans-jp: 'Noto Sans JP', sans-serif;
   --font-new-tegomin: 'New Tegomin', serif;
-  
 }
 
 @media (prefers-color-scheme: dark) {
@@ -23,8 +22,6 @@ body {
   font-family: 'Noto Sans JP', sans-serif;
 }
 
-
-
 @layer utilities {
   .text-balance {
     text-wrap: balance;
@@ -34,4 +31,18 @@ body {
 /* スパム対策用 */
 .no-spam {
   display: none;
+}
+
+/* スクロールバーのスタイル */
+.scrollbar-custom::-webkit-scrollbar {
+  width: 6px; /* スクロールバーの幅 */
+}
+
+.scrollbar-custom::-webkit-scrollbar-thumb {
+  background-color: #d3b25b; /* スクロールバーの色 */
+  border-radius: 4px; /* スクロールバーの角丸 */
+}
+
+.scrollbar-custom::-webkit-scrollbar-track {
+  background-color: #fff9e5; /* スクロールバーの背景 */
 }

--- a/app/pages/top/components/InfosClient.tsx
+++ b/app/pages/top/components/InfosClient.tsx
@@ -23,26 +23,28 @@ const InfosClient: React.FC<Props> = ({ infos }) => {
         <p className="text-center">
           <TextStyle styleType="section_title">お知らせ</TextStyle>
         </p>
-        <div className="overflow-y-auto max-h-96">
-          {infos.map((info) => (
-            <div key={info.番号}>
-              <p>
-                <TextStyle styleType="body3_khaki">{info.投稿日時}</TextStyle>
-              </p>
-              <p>
-                <TextStyle styleType="body2_bold_khaki">
-                  {info.タイトル}
-                </TextStyle>
-              </p>
-              <p>
-                <TextStyle styleType="body3">{info.内容}</TextStyle>
-              </p>
+        <div className="overflow-y-auto max-h-96 scrollbar-custom">
+          <div className="pr-2">
+            {infos.map((info) => (
+              <div key={info.番号}>
+                <p>
+                  <TextStyle styleType="body3_khaki">{info.投稿日時}</TextStyle>
+                </p>
+                <p>
+                  <TextStyle styleType="body2_bold_khaki">
+                    {info.タイトル}
+                  </TextStyle>
+                </p>
+                <p>
+                  <TextStyle styleType="body3">{info.内容}</TextStyle>
+                </p>
 
-              <div className="py-4">
-                <Line className="border-main" />
+                <div className="py-4">
+                  <Line className="border-main" />
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
       </Frame>
     </div>

--- a/app/pages/top/components/InfosClient.tsx
+++ b/app/pages/top/components/InfosClient.tsx
@@ -1,37 +1,52 @@
 'use client';
 
+import Frame from '@/app/components/frame';
+import Line from '@/app/components/line';
 import React from 'react';
 import TextStyle from '../../../components/text_style';
-import Frame from "@/app/components/frame";
 
 interface Info {
-    番号: string;
-    投稿日時: string;
-    タイトル: string;
-    内容: string;
+  番号: string;
+  投稿日時: string;
+  タイトル: string;
+  内容: string;
 }
 
 interface Props {
-    infos: Info[];
+  infos: Info[];
 }
 
 const InfosClient: React.FC<Props> = ({ infos }) => {
-    return (
+  return (
     <div>
-        <Frame>
-            <p className='text-center'>
-                <TextStyle styleType="section_title">お知らせ</TextStyle>
-            </p>
-            {infos.map((info) => (
-                <div key={info.番号}>
-                    <p><TextStyle styleType="body3_khaki">{info.投稿日時}</TextStyle></p>
-                    <p><TextStyle styleType="body2_bold_khaki">{info.タイトル}</TextStyle></p>
-                    <p><TextStyle styleType="body3">{info.内容}</TextStyle></p>
-                </div>
-            ))}
-        </Frame>
+      <Frame>
+        <p className="text-center">
+          <TextStyle styleType="section_title">お知らせ</TextStyle>
+        </p>
+        <div className="overflow-y-auto max-h-96">
+          {infos.map((info) => (
+            <div key={info.番号}>
+              <p>
+                <TextStyle styleType="body3_khaki">{info.投稿日時}</TextStyle>
+              </p>
+              <p>
+                <TextStyle styleType="body2_bold_khaki">
+                  {info.タイトル}
+                </TextStyle>
+              </p>
+              <p>
+                <TextStyle styleType="body3">{info.内容}</TextStyle>
+              </p>
+
+              <div className="py-4">
+                <Line className="border-main" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </Frame>
     </div>
-    );
+  );
 };
 
 export default InfosClient;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
なし

# 概要
お知らせが追加されてどんどん長くならないように、スクロールできるようにしました


# 実装詳細



# 画面スクリーンショット等
<img width="271" alt="image" src="https://github.com/user-attachments/assets/a2d9f47a-45f1-4be2-9c27-37c64df47fe2" />



# テスト項目
- [x] デザインが崩れていないか
- [x] PC、スマホの両方で操作可能か
- [x] デザインやセクションの大きさに気になるところはないか

# 備考
