### PR TITLE
アクセスページにGoogleマップを追加

### DIFF
--- a/app/pages/access/components/googlemap.tsx
+++ b/app/pages/access/components/googlemap.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+const GoogleMap: React.FC = () => {
+  return (
+    <div className="relative">
+      {/* 金色の枠 */}
+      <div className="border-4 border-[#D4AF37] bg-white p-2 shadow-lg">
+        <iframe
+          src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3168.551502862745!2d138.7779765!3d37.424074399999995!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5ff5aedc609c6e15%3A0x75a37d3645c0f37a!2z5Zu956uL5aSn5a2m5rOV5Lq6IOmVt-WyoeaKgOihk-enkeWtpuWkp-Wtpg!5e0!3m2!1sja!2sjp!4v1748408545877!5m2!1sja!2sjp"
+          width="400"
+          height="300"
+          style={{ border: 0 }}
+          allowFullScreen
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          title="長岡技術科学大学 アクセスマップ"
+          className="block"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default GoogleMap;

--- a/app/pages/access/page.tsx
+++ b/app/pages/access/page.tsx
@@ -1,9 +1,18 @@
-import React from "react";
+import TextStyle from '../../components/text_style';
+import GoogleMap from './components/googlemap';
 
 export default function AccessPage() {
   return (
-    <div>
-      <h1>Access Page</h1>
+    <div className="w-full min-h-screen flex flex-col items-center justify-center bg-base py-12">
+      <div className="text-center mb-4">
+        <h1 className="mb-6">
+          <TextStyle styleType="title">アクセス</TextStyle>
+        </h1>
+        <h2 className="mb-2">
+          <TextStyle styleType="section_title">大学Googleマップ</TextStyle>
+        </h2>
+      </div>
+      <GoogleMap />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
アクセスページのGoogleマップコンポーネントを追加しました。

## 対応Issue
resolve #83

## 変更内容
- `app/pages/access/components/googlemap.tsx`を新規作成
- GoogleMap埋め込みコンポーネントを実装
- `app/pages/access/page.tsx`を更新


## 実装詳細
### GoogleMapコンポーネント
- 長岡技術科学大学のGoogleMap埋め込み
- 400x300pxのサイズ
- 金色の枠線（border-[#D4AF37]）でデザイン統一

## 画面スクリーンショット等
<!-- 実装後にスクリーンショットを追加予定 -->
<img width="729" alt="スクリーンショット 2025-05-28 14 10 04" src="https://github.com/user-attachments/assets/b4f9a92e-682b-481e-857e-3daca5fc5519" />


## テスト項目
- [ ] アクセスページが正常に表示される
- [ ] GoogleMapが適切に埋め込まれている