### PR TITLE
[feat]開催場所セクションのコンポーネント作業

### DIFF
--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -1,4 +1,5 @@
 export const runtime = 'edge';
+import DetailMap from '@/src/components/common/detail_map';
 import { getExhExpDataById } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
 import Image from 'next/image';
@@ -73,20 +74,7 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
 
         <hr className="border-t-2 border-red-400 my-8" />
 
-        <div className="border-4 border-yellow-400 p-8 max-w-2xl mx-auto">
-          <h2 className="text-2xl text-center font-bold mb-4">開催場所</h2>
-          <p className="text-xl text-center mb-4">{item.開催場所}</p>
-          {/* Map image placeholder */}
-          <div className="bg-gray-200 w-full h-64 flex items-center justify-center mb-4">
-            地図画像
-          </div>
-          <Link
-            href="/map"
-            className="block w-full bg-yellow-500 text-white text-center py-3 rounded-md font-bold"
-          >
-            マップページへ
-          </Link>
-        </div>
+        <DetailMap location={item.開催場所} />
 
         <div className="text-center mt-12">
           <Link

--- a/src/components/common/detail_map.tsx
+++ b/src/components/common/detail_map.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+
+type DetailMapProps = {
+  location: string;
+};
+
+const DetailMap = ({ location }: DetailMapProps) => {
+  return (
+    <div className="border-4 border-yellow-400 p-8 max-w-2xl mx-auto">
+      <h2 className="text-2xl text-center font-bold mb-4">開催場所</h2>
+      <p className="text-xl text-center mb-4">{location}</p>
+      {/* Map image placeholder */}
+      <div className="bg-gray-200 w-full h-64 flex items-center justify-center mb-4">
+        地図画像
+      </div>
+      <Link
+        href="/map"
+        className="block w-full bg-yellow-500 text-white text-center py-3 rounded-md font-bold"
+      >
+        マップページへ
+      </Link>
+    </div>
+  );
+};
+
+export default DetailMap;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #114 


# 概要
<!-- 開発内容の概要を記載 -->
展示・体験詳細ページに表示される「開催場所」セクションを共通コンポーネントとして分離した。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `src/components/common/detail_map.tsx` を新規作成し、開催場所の表示するようにした。
- 元々の構造的に同様のUIを持つ他の詳細ページでも開催場所セクションを再利用できるようになってると思う！

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 展示・体験の詳細ページ (`/event/exh_exp/[id]`) で、開催場所セクションが正しく表示されているか。
- [x] 「マップページへ」のボタンが `/map` へ正しくリンクしているか。

# 備考