### PR TITLE
[feat]タグ検索のコンポーネント分け

### DIFF
--- a/src/app/event/exh_exp/page.tsx
+++ b/src/app/event/exh_exp/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import TagModal from '@/src/components/common/tag';
 import CellContent from '@/src/components/event/exh_exp/CellContent';
 import { getAllExhExpData } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
@@ -76,43 +77,13 @@ export default function ExhExpPage() {
         </div>
       </div>
 
-      {isModalOpen && (
-        <div
-          className="fixed inset-0 bg-[#654321] flex flex-col items-center justify-center z-50 p-8"
-          style={{ backgroundColor: 'rgba(101, 67, 33, 1)' }} // #654321
-        >
-          <div className="w-full max-w-md text-[#F8F5E9]">
-            <h2 className="text-3xl font-bold mb-8 text-center">タグ検索</h2>
-            <div className="space-y-4 mb-10">
-              {allTags.map((tag) => (
-                <label key={tag} className="flex items-center text-2xl">
-                  <input
-                    type="checkbox"
-                    checked={selectedTags.includes(tag)}
-                    onChange={() => handleTagChange(tag)}
-                    className="appearance-none h-8 w-8 border-2 border-[#F8F5E9] rounded-sm bg-transparent checked:bg-[#F8F5E9] checked:border-transparent mr-4"
-                  />
-                  <span>{tag}</span>
-                </label>
-              ))}
-            </div>
-            <div className="flex justify-between items-center">
-              <button
-                onClick={() => setIsModalOpen(false)}
-                className="text-2xl"
-              >
-                戻る
-              </button>
-              <button
-                onClick={() => setIsModalOpen(false)}
-                className="px-12 py-3 bg-[#F8F5E9] text-[#654321] text-2xl font-bold rounded-lg"
-              >
-                検索
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      <TagModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        allTags={allTags}
+        selectedTags={selectedTags}
+        onTagChange={handleTagChange}
+      />
     </>
   );
 }

--- a/src/components/common/tag.tsx
+++ b/src/components/common/tag.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+type TagModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  allTags: string[];
+  selectedTags: string[];
+  onTagChange: (tag: string) => void;
+};
+
+const TagModal = ({
+  isOpen,
+  onClose,
+  allTags,
+  selectedTags,
+  onTagChange,
+}: TagModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-[#654321] flex flex-col items-center justify-center z-50 p-8"
+      style={{ backgroundColor: 'rgba(101, 67, 33, 1)' }} // #654321
+    >
+      <div className="w-full max-w-md text-[#F8F5E9]">
+        <h2 className="text-3xl font-bold mb-8 text-center">タグ検索</h2>
+        <div className="space-y-4 mb-10">
+          {allTags.map((tag) => (
+            <label key={tag} className="flex items-center text-2xl">
+              <input
+                type="checkbox"
+                checked={selectedTags.includes(tag)}
+                onChange={() => onTagChange(tag)}
+                className="appearance-none h-8 w-8 border-2 border-[#F8F5E9] rounded-sm bg-transparent checked:bg-[#F8F5E9] checked:border-transparent mr-4"
+              />
+              <span>{tag}</span>
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-between items-center">
+          <button onClick={onClose} className="text-2xl">
+            戻る
+          </button>
+          <button
+            onClick={onClose}
+            className="px-12 py-3 bg-[#F8F5E9] text-[#654321] text-2xl font-bold rounded-lg"
+          >
+            検索
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TagModal;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #115

# 概要
<!-- 開発内容の概要を記載 -->
展示・体験ページで利用されているタグ検索のオーバーレイメニューを共通コンポーネントとして分離しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `src/components/common/tag.tsx` を新規作成し、モーダル（オーバーレイ）の UI とロジックを `TagModal` コンポーネントとして実装しました。
- `src/app/event/exh_exp/page.tsx` をリファクタリングし、元々あった JSX を新しく作成した `<TagModal />` コンポーネントに置き換えました。

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
- [ ] 展示・体験ページ (`/event/exh_exp`) で「タグ検索」ボタンを押すと、オーバーレイメニューが正しく表示されるか。
- [ ] タグを選択・解除できるか。
- [ ] 「戻る」または「検索」ボタンでメニューを閉じられるか。
- [ ] 選択したタグに基づいて、表示される企画が正しくフィルタリングされるか。

# 備考
<!-- 実装していて困った箇所・質問など -->
