### PR TITLE
Feat/oniwa/109/create exhexp id design

### DIFF
--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -1,6 +1,7 @@
 export const runtime = 'edge';
 import BackFrame from '@/src/components/common/back_frame';
 import DetailMap from '@/src/components/common/detail_map';
+import Line from '@/src/components/common/line';
 import ReturnEventButton from '@/src/components/common/return_event_button';
 import TextStyle from '@/src/components/common/text_style';
 import { getExhExpDataById } from '@/src/lib/exh_exp';
@@ -26,34 +27,35 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
 
   return (
     <BackFrame>
-      <div className="container mx-auto px-4 py-8 pb-8">
+      <div className="container mx-auto py-8">
         <ReturnEventButton href="/event/exh_exp" />
         <div className="text-center">
           <TextStyle styleType="section_title">展示・体験</TextStyle>
-          <p className="text-h2">{item.出店タイトル}</p>
+          <p className="text-h2 pt-2 py-4">{item.出店タイトル}</p>
         </div>
-
-        <div className="w-full aspect-square flex items-center justify-center relative max-w-lg mx-auto">
-          {imageUrl ? (
-            <Image
-              src={imageUrl}
-              alt={item.出店タイトル || 'image'}
-              fill
-              className="object-contain"
-              unoptimized
-            />
-          ) : (
-            <div className="w-full h-full flex flex-col items-center justify-center text-white">
+        <div className="pb-4 pt-4">
+          <div className="w-[70%] aspect-square flex items-center justify-center relative max-w-lg mx-auto">
+            {imageUrl ? (
               <Image
-                src="/icon/44thlogo.svg"
-                alt="logo"
-                width={150}
-                height={150}
+                src={imageUrl}
+                alt={item.出店タイトル || 'image'}
+                fill
                 className="object-contain"
+                unoptimized
               />
-              <p className="mt-2">NO IMAGE</p>
-            </div>
-          )}
+            ) : (
+              <div className="w-full h-full flex flex-col items-center justify-center text-white">
+                <Image
+                  src="/icon/44thlogo.svg"
+                  alt="logo"
+                  width={150}
+                  height={150}
+                  className="object-contain"
+                />
+                <p className="mt-2">NO IMAGE</p>
+              </div>
+            )}
+          </div>
         </div>
 
         <p className="text-center my-8 text-body1">{item.PR文}</p>
@@ -69,7 +71,7 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
           ))}
         </div>
 
-        <hr className="border-t-2 border-red-400 my-8" />
+        <Line className="my-8" />
 
         <DetailMap location={item.開催場所} />
 

--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -1,5 +1,8 @@
 export const runtime = 'edge';
+import BackFrame from '@/src/components/common/back_frame';
 import DetailMap from '@/src/components/common/detail_map';
+import LinkButton from '@/src/components/common/link_button';
+import TextStyle from '@/src/components/common/text_style';
 import { getExhExpDataById } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
 import Image from 'next/image';
@@ -22,18 +25,19 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
   const imageUrl = item.番号 ? `/images/exh_exp/${item.番号}.png` : null;
 
   return (
-    <div className="bg-[#F8F5E9] min-h-screen font-serif text-[#432F2F]">
+    <BackFrame>
       <div className="container mx-auto px-4 py-8">
-        <Link
-          href="/event/exh_exp"
-          className="inline-block bg-gray-400 text-white px-4 py-2 rounded mb-4"
-        >
-          {'<< 戻る'}
-        </Link>
-
-        <div className="text-center my-8">
-          <p className="text-2xl">展示・体験</p>
-          <h1 className="text-4xl font-bold">{item.出店タイトル}</h1>
+        <div className="flex justify-start">
+          <LinkButton
+            href="/event/exh_exp"
+            className="inline-block bg-gray text-white pr-4 pl-4 pt-2 pb-2"
+          >
+            {'<< 戻る'}
+          </LinkButton>
+        </div>
+        <div className="text-center">
+          <TextStyle styleType="section_title">展示・体験</TextStyle>
+          <p className="text-h2">{item.出店タイトル}</p>
         </div>
 
         <div className="w-full aspect-square flex items-center justify-center relative max-w-lg mx-auto">
@@ -104,6 +108,6 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
           </Link>
         </div>
       </div>
-    </div>
+    </BackFrame>
   );
 }

--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -1,7 +1,7 @@
 export const runtime = 'edge';
 import BackFrame from '@/src/components/common/back_frame';
 import DetailMap from '@/src/components/common/detail_map';
-import LinkButton from '@/src/components/common/link_button';
+import ReturnEventButton from '@/src/components/common/return_event_button';
 import TextStyle from '@/src/components/common/text_style';
 import { getExhExpDataById } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
@@ -26,15 +26,8 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
 
   return (
     <BackFrame>
-      <div className="container mx-auto px-4 py-8">
-        <div className="flex justify-start">
-          <LinkButton
-            href="/event/exh_exp"
-            className="inline-block bg-gray text-white pr-4 pl-4 pt-2 pb-2"
-          >
-            {'<< 戻る'}
-          </LinkButton>
-        </div>
+      <div className="container mx-auto px-4 py-8 pb-8">
+        <ReturnEventButton href="/event/exh_exp" />
         <div className="text-center">
           <TextStyle styleType="section_title">展示・体験</TextStyle>
           <p className="text-h2">{item.出店タイトル}</p>
@@ -63,7 +56,7 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
           )}
         </div>
 
-        <p className="text-center my-8 max-w-2xl mx-auto">{item.PR文}</p>
+        <p className="text-center my-8 text-body1">{item.PR文}</p>
 
         <div className="flex justify-center gap-4 my-8">
           {tags.map((tag, index) => (
@@ -80,14 +73,7 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
 
         <DetailMap location={item.開催場所} />
 
-        <div className="text-center mt-12">
-          <Link
-            href="/event"
-            className="inline-block bg-gray-400 text-white px-6 py-3 rounded"
-          >
-            {'<< イベントページへ戻る'}
-          </Link>
-        </div>
+        <ReturnEventButton size={'large'} href="/event/exh_exp" />
 
         <div className="border-4 border-yellow-400 p-4 mt-16 max-w-2xl mx-auto">
           <div className="w-full aspect-video bg-black flex items-center justify-center relative">

--- a/src/components/common/detail_map.tsx
+++ b/src/components/common/detail_map.tsx
@@ -1,4 +1,7 @@
-import Link from 'next/link';
+'use client';
+import Frame from './frame';
+import LinkButton from './link_button';
+import TextStyle from './text_style';
 
 type DetailMapProps = {
   location: string;
@@ -6,19 +9,22 @@ type DetailMapProps = {
 
 const DetailMap = ({ location }: DetailMapProps) => {
   return (
-    <div className="border-4 border-yellow-400 p-8 max-w-2xl mx-auto">
-      <h2 className="text-2xl text-center font-bold mb-4">開催場所</h2>
-      <p className="text-xl text-center mb-4">{location}</p>
-      {/* Map image placeholder */}
-      <div className="bg-gray-200 w-full h-64 flex items-center justify-center mb-4">
-        地図画像
-      </div>
-      <Link
-        href="/map"
-        className="block w-full bg-yellow-500 text-white text-center py-3 rounded-md font-bold"
-      >
-        マップページへ
-      </Link>
+    <div>
+      <Frame>
+        <TextStyle styleType="section_title" className="text-center">
+          開催場所
+        </TextStyle>
+        <TextStyle styleType="body1" className="text-center">
+          {location}
+        </TextStyle>
+        {/* Map image placeholder */}
+        <div className="bg-gray-200 w-full h-64 flex items-center justify-center mb-4">
+          地図画像
+        </div>
+        <LinkButton href="/map" className="bg-second">
+          マップページへ
+        </LinkButton>
+      </Frame>
     </div>
   );
 };

--- a/src/components/common/detail_map.tsx
+++ b/src/components/common/detail_map.tsx
@@ -22,7 +22,7 @@ const DetailMap = ({ location }: DetailMapProps) => {
           地図画像
         </div>
         <LinkButton href="/map" className="bg-second">
-          マップページへ
+          <TextStyle styleType="body1" className="text-white">マップページへ</TextStyle>
         </LinkButton>
       </Frame>
     </div>

--- a/src/components/common/return_event_button.tsx
+++ b/src/components/common/return_event_button.tsx
@@ -1,0 +1,38 @@
+'use client';
+import Link from 'next/link';
+import React from 'react';
+
+interface ReturnEventButtonProps {
+  className?: string;
+  size?: 'small' | 'large';
+  children?: React.ReactNode;
+  href: string;
+}
+const ReturnEventButton: React.FC<ReturnEventButtonProps> = ({
+  size = 'small',
+  href,
+  className,
+}) => {
+  const label = size === 'small' ? '<<戻る' : '<<一覧へ戻る';
+
+  return (
+    <div
+      className={`w-full pt-8 pb-8
+                    ${
+                      size === 'small'
+                        ? 'flex justify-start'
+                        : 'flex justify-center'
+                    } ${className}`}
+    >
+      <div className="flex justify-center">
+        <Link
+          href={href}
+          className={`px-12  py-4 text-white bg-gray rounded-sm text-body2 shadow_button text-center ${className}`}
+        >
+          {label}
+        </Link>
+      </div>
+    </div>
+  );
+};
+export default ReturnEventButton;

--- a/src/components/common/return_event_button.tsx
+++ b/src/components/common/return_event_button.tsx
@@ -27,7 +27,7 @@ const ReturnEventButton: React.FC<ReturnEventButtonProps> = ({
       <div className="flex justify-center">
         <Link
           href={href}
-          className={`px-12  py-4 text-white bg-gray rounded-sm text-body2 shadow_button text-center ${className}`}
+          className={`px-6  py-2 text-white bg-gray rounded-sm text-body2 shadow_button text-center ${className}`}
         >
           {label}
         </Link>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
resolve #109 

# 概要
展示体験の詳細ページのデザインを作成した
その過程で、戻るボタンのコンポーネントRetrunEventButtonを作成した


# 実装詳細
<!-- 具体的な開発内容を記載 -->
・DetailMapコンポーネントのデザイン作成
・展示体験のidページのデザイン作成
※idページの下の広告セクションは仮置きのため無視でいいです

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="377" alt="image" src="https://github.com/user-attachments/assets/c3d97980-a640-4f99-8107-85710d2f2977" />
<img width="222" alt="image" src="https://github.com/user-attachments/assets/18d18e93-eea9-4522-86b1-cec8dbffaac4" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] 展示体験の詳細ページ（...event/exh_exp/1など）のデザインが崩れていないか
- [ ] ↑ページの「<<戻る」「<<一覧へ戻る」ボタンで、展示体験の出店一覧ページに戻れるか
- [ ] 他の展示体験の詳細ページにもデザインが反映されているか

# 備考
<!-- 実装していて困った箇所・質問など -->