### PR TITLE
[feat]タグ検索コンポーネントの作成

### DIFF
--- a/src/app/event/exh_exp/page.tsx
+++ b/src/app/event/exh_exp/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import TagModal from '@/src/components/common/tag';
+import Tag from '@/src/components/common/tag';
+import TagModal from '@/src/components/common/tag_modal';
 import CellContent from '@/src/components/event/exh_exp/CellContent';
 import { getAllExhExpData } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
@@ -46,14 +47,11 @@ export default function ExhExpPage() {
 
           <h1 className="text-4xl text-center font-bold my-8">展示・体験</h1>
 
-          <div className="text-center mb-8">
-            <button
-              onClick={() => setIsModalOpen(true)}
-              className="border-2 border-red-500 text-red-500 px-8 py-2 rounded-md"
-            >
-              タグ検索
-            </button>
-          </div>
+          <Tag
+            selectedTags={selectedTags}
+            onSearchClick={() => setIsModalOpen(true)}
+            onResetClick={() => setSelectedTags([])}
+          />
 
           <hr className="border-t-2 border-red-400 mb-8" />
 

--- a/src/components/common/tag.tsx
+++ b/src/components/common/tag.tsx
@@ -1,56 +1,45 @@
 'use client';
 
-type TagModalProps = {
-  isOpen: boolean;
-  onClose: () => void;
-  allTags: string[];
+type TagProps = {
   selectedTags: string[];
-  onTagChange: (tag: string) => void;
+  onSearchClick: () => void;
+  onResetClick: () => void;
 };
 
-const TagModal = ({
-  isOpen,
-  onClose,
-  allTags,
-  selectedTags,
-  onTagChange,
-}: TagModalProps) => {
-  if (!isOpen) return null;
+const Tag = ({ selectedTags, onSearchClick, onResetClick }: TagProps) => {
+  const hasSelectedTags = selectedTags.length > 0;
 
   return (
-    <div
-      className="fixed inset-0 bg-[#654321] flex flex-col items-center justify-center z-50 p-8"
-      style={{ backgroundColor: 'rgba(101, 67, 33, 1)' }} // #654321
-    >
-      <div className="w-full max-w-md text-[#F8F5E9]">
-        <h2 className="text-3xl font-bold mb-8 text-center">タグ検索</h2>
-        <div className="space-y-4 mb-10">
-          {allTags.map((tag) => (
-            <label key={tag} className="flex items-center text-2xl">
-              <input
-                type="checkbox"
-                checked={selectedTags.includes(tag)}
-                onChange={() => onTagChange(tag)}
-                className="appearance-none h-8 w-8 border-2 border-[#F8F5E9] rounded-sm bg-transparent checked:bg-[#F8F5E9] checked:border-transparent mr-4"
-              />
-              <span>{tag}</span>
-            </label>
-          ))}
-        </div>
-        <div className="flex justify-between items-center">
-          <button onClick={onClose} className="text-2xl">
-            戻る
-          </button>
+    <div className="text-center mb-8">
+      {hasSelectedTags ? (
+        <div>
           <button
-            onClick={onClose}
-            className="px-12 py-3 bg-[#F8F5E9] text-[#654321] text-2xl font-bold rounded-lg"
+            onClick={onResetClick}
+            className="inline-flex items-center justify-center h-[49px] px-[54px] py-2 text-white bg-accent rounded-sm text-body2 shadow-button text-center mb-4"
           >
-            検索
+            × タグをリセット
           </button>
+          <div className="flex justify-center gap-2 flex-wrap">
+            {selectedTags.map((tag) => (
+              <span
+                key={tag}
+                className="border border-accent text-accent px-3 py-1 rounded-full text-sm"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
         </div>
-      </div>
+      ) : (
+        <button
+          onClick={onSearchClick}
+          className="inline-flex items-center justify-center h-[49px] px-[54px] py-2 text-accent bg-base border-2 border-accent rounded-sm text-body2 shadow-button text-center"
+        >
+          タグ検索
+        </button>
+      )}
     </div>
   );
 };
 
-export default TagModal;
+export default Tag;

--- a/src/components/common/tag_modal.tsx
+++ b/src/components/common/tag_modal.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+type TagModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  allTags: string[];
+  selectedTags: string[];
+  onTagChange: (tag: string) => void;
+};
+
+const TagModal = ({
+  isOpen,
+  onClose,
+  allTags,
+  selectedTags,
+  onTagChange,
+}: TagModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-[#654321] flex flex-col items-center justify-center z-50 p-8"
+      style={{ backgroundColor: 'rgba(101, 67, 33, 1)' }} // #654321
+    >
+      <div className="w-full max-w-md text-[#F8F5E9]">
+        <h2 className="text-3xl font-bold mb-8 text-center">タグ検索</h2>
+        <div className="space-y-4 mb-10">
+          {allTags.map((tag) => (
+            <label key={tag} className="flex items-center text-2xl">
+              <input
+                type="checkbox"
+                checked={selectedTags.includes(tag)}
+                onChange={() => onTagChange(tag)}
+                className="appearance-none h-8 w-8 border-2 border-[#F8F5E9] rounded-sm bg-transparent checked:bg-[#F8F5E9] checked:border-transparent mr-4"
+              />
+              <span>{tag}</span>
+            </label>
+          ))}
+        </div>
+        <div className="flex justify-between items-center">
+          <button onClick={onClose} className="text-2xl">
+            戻る
+          </button>
+          <button
+            onClick={onClose}
+            className="px-12 py-3 bg-[#F8F5E9] text-[#654321] text-2xl font-bold rounded-lg"
+          >
+            検索
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TagModal;


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #122

# 概要
<!-- 開発内容の概要を記載 -->
展示・体験ページで利用されているタグ検索機能を、状態に応じて表示が切り替わる単一のコンポーネントとして再構築しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
1.  コンポーネントの名前変更:
    -   従来のタグ検索モーダル `src/components/common/tag.tsx` を `src/components/common/tag_modal.tsx` に変更しました。

2.  新規コンポーネント `tag.tsx` の作成:
    -   `src/components/common/tag.tsx` を新たに作成しました。
    -   選択されたタグ (`selectedTags`) の有無に応じて、以下の要素を出し分けて表示するようにしてます。
        -   **タグ未選択時**: 「タグ検索」ボタン
        -   **タグ選択時**: 「× タグをリセット」ボタンと、選択中のタグ一覧



# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="1470" alt="スクリーンショット 2025-07-05 0 29 27" src="https://github.com/user-attachments/assets/5c19caf2-c153-4531-bb62-26279d8fdfc7" />
<img width="1470" alt="スクリーンショット 2025-07-05 0 29 37" src="https://github.com/user-attachments/assets/12b04ebe-38aa-4a01-a076-ff6d7f8c8f94" />


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] 「タグ検索」ボタンをクリックしてモーダルを開き、タグをいくつか選択して「検索」ボタンを押す。
- [x] ページに戻った際、「タグ検索」ボタンが「× タグをリセット」ボタンと選択中タグ一覧に切り替わっているか。
- [x] 「× タグをリセット」ボタンを押すと、タグの選択がすべて解除され、表示が「タグ検索」ボタンに戻るか。

# 備考
<!-- 実装していて困った箇所・質問など -->
