### PR TITLE
【展示体験】一覧ページのデザイン実装

### DIFF
--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -27,7 +27,7 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
 
   return (
     <BackFrame>
-      <div className="container mx-auto py-8">
+      <div>
         <ReturnEventButton href="/event/exh_exp" />
         <div className="text-center">
           <TextStyle styleType="section_title">展示・体験</TextStyle>

--- a/src/app/event/exh_exp/page.tsx
+++ b/src/app/event/exh_exp/page.tsx
@@ -43,7 +43,7 @@ export default function ExhExpPage() {
       <div>
         <BackFrame>
           <ReturnEventButton href="/event" />
-          <div className="container px-4 py-8">
+          <div className="container px-4">
             <div className="text-center py-8">
               <TextStyle styleType="title">展示・体験</TextStyle>
             </div>

--- a/src/app/event/exh_exp/page.tsx
+++ b/src/app/event/exh_exp/page.tsx
@@ -1,7 +1,11 @@
 'use client';
 
+import BackFrame from '@/src/components/common/back_frame';
+import Line from '@/src/components/common/line';
+import ReturnEventButton from '@/src/components/common/return_event_button';
 import Tag from '@/src/components/common/tag';
 import TagModal from '@/src/components/common/tag_modal';
+import TextStyle from '@/src/components/common/text_style';
 import CellContent from '@/src/components/event/exh_exp/CellContent';
 import { getAllExhExpData } from '@/src/lib/exh_exp';
 import { ExhExpItem } from '@/src/types/exh_exp';
@@ -36,43 +40,46 @@ export default function ExhExpPage() {
 
   return (
     <>
-      <div className="bg-[#F8F5E9] min-h-screen font-serif text-[#432F2F]">
-        <div className="container mx-auto px-4 py-8">
-          <Link
-            href="/event"
-            className="inline-block bg-gray-400 text-white px-4 py-2 rounded mb-4"
-          >
-            {'<< 戻る'}
-          </Link>
+      <div>
+        <BackFrame>
+          <ReturnEventButton href="/event" />
+          <div className="container px-4 py-8">
+            <div className="text-center py-8">
+              <TextStyle styleType="title">展示・体験</TextStyle>
+            </div>
 
-          <h1 className="text-4xl text-center font-bold my-8">展示・体験</h1>
-
-          <Tag
-            selectedTags={selectedTags}
-            onSearchClick={() => setIsModalOpen(true)}
-            onResetClick={() => setSelectedTags([])}
-          />
-
-          <hr className="border-t-2 border-red-400 mb-8" />
-
-          <main
-            className="grid grid-cols-2 gap-8"
-            style={{
-              backgroundImage: "url('/assets/illust_people_1.svg')",
-              backgroundRepeat: 'no-repeat',
-              backgroundPosition: 'center',
-              backgroundSize: 'contain',
-            }}
-          >
-            {filteredData.map((item) => (
-              <div key={item.番号} className="text-center">
-                <Link href={`/event/exh_exp/${item.番号 || ''}`}>
-                  <CellContent imageId={item.番号} title={item.出店タイトル} />
-                </Link>
-              </div>
-            ))}
-          </main>
-        </div>
+            <Tag
+              selectedTags={selectedTags}
+              onSearchClick={() => setIsModalOpen(true)}
+              onResetClick={() => setSelectedTags([])}
+            />
+            <div className="py-4">
+              <Line className="accenat" />
+            </div>
+            <main
+              className="grid grid-cols-2 gap-8"
+              style={{
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'center',
+                backgroundSize: 'contain',
+              }}
+            >
+              {filteredData.map((item) => (
+                <div key={item.番号} className="text-center">
+                  <Link href={`/event/exh_exp/${item.番号 || ''}`}>
+                    <TextStyle styleType="body2">
+                      <CellContent
+                        imageId={item.番号}
+                        title={item.出店タイトル}
+                      />
+                    </TextStyle>
+                  </Link>
+                </div>
+              ))}
+            </main>
+            <ReturnEventButton size="large_event" href="/event" />
+          </div>
+        </BackFrame>
       </div>
 
       <TagModal

--- a/src/components/common/return_event_button.tsx
+++ b/src/components/common/return_event_button.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 
 interface ReturnEventButtonProps {
   className?: string;
-  size?: 'small' | 'large';
+  size?: 'small' | 'large' | 'large_event';
   children?: React.ReactNode;
   href: string;
 }
@@ -13,7 +13,18 @@ const ReturnEventButton: React.FC<ReturnEventButtonProps> = ({
   href,
   className,
 }) => {
-  const label = size === 'small' ? '<<戻る' : '<<一覧へ戻る';
+  const label = (() => {
+    switch (size) {
+      case 'small':
+        return '<<戻る';
+      case 'large':
+        return '<<一覧へ戻る';
+      case 'large_event':
+        return '<<イベントページへ戻る';
+      default:
+        return '<<戻る';
+    }
+  })();
 
   return (
     <div

--- a/src/components/event/exh_exp/CellContent.tsx
+++ b/src/components/event/exh_exp/CellContent.tsx
@@ -18,7 +18,7 @@ export default function CellContent({ imageId, title }: CellContentProps) {
             src={imageUrl}
             alt={title || 'image'}
             fill
-            className="object-contain"
+            className="object-contain shadow-button"
             unoptimized // If the images are static and already optimized
           />
         ) : (
@@ -34,7 +34,7 @@ export default function CellContent({ imageId, title }: CellContentProps) {
           </div>
         )}
       </div>
-      <p className="mt-2 font-bold">{title || '出店タイトル'}</p>
+      <p className="mt-2">{title || '出店タイトル'}</p>
     </div>
   );
 }


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue

resolve #129 

# 概要
一覧ページのデザインを作成


# 実装詳細
一部DL部分のコンポーネントを書き換えました（テキストスタイルの適用のため）


# 画面スクリーンショット等
<img width="224" alt="image" src="https://github.com/user-attachments/assets/7d6f0146-b1a9-4b94-99bb-5a6408f28425" />


# テスト項目
- [ ] 上下の戻るボタンによってイベントページに戻れるか
- [ ] 詳細ページへのリンクが適切に動作するか
- [ ] 

# 備考
<!-- 実装していて困った箇所・質問など -->