### PR TITLE
[fix]飲食を食品販売に名称変更

### DIFF
--- a/src/app/food/[id]/page.tsx
+++ b/src/app/food/[id]/page.tsx
@@ -30,7 +30,7 @@ export default async function FoodDetailPage({ params }: FoodDetailProps) {
       <div className="container mx-auto py-8">
         <ReturnEventButton href="/food" />
         <div className="text-center">
-          <TextStyle styleType="section_title">飲食</TextStyle>
+          <TextStyle styleType="section_title">食品販売</TextStyle>
           <p className="text-h2 pt-2 py-4">{item.出店タイトル}</p>
         </div>
         <div className="pb-4 pt-4">

--- a/src/app/food/page.tsx
+++ b/src/app/food/page.tsx
@@ -54,7 +54,7 @@ export default function FoodPage() {
             {'<< 戻る'}
           </Link>
 
-          <h1 className="text-4xl text-center font-bold my-8">飲食</h1>
+          <h1 className="text-4xl text-center font-bold my-8">食品販売</h1>
 
           <Tag
             selectedTags={selectedTags}

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -23,12 +23,22 @@ export default function Header() {
     <header className="fixed top-0 left-0 w-full flex justify-between pb-4 pt-4 pl-[3%] pr-[3%] bg-gradient-to-b from-header_grad bg-blend-darken z-50">
       <div className="flex">
         <Link href={'/'}>
-          <Image src="/icon/44thlogo_shadow.png" alt="44th_icon" width={40} height={40} />
+          <Image
+            src="/icon/44thlogo_shadow.png"
+            alt="44th_icon"
+            width={40}
+            height={40}
+          />
         </Link>
       </div>
       <div className="flex">
         <button onClick={toggleMenu} aria-label="メニューを開く">
-          <Image src="/icon/BiMenu_shadow.png" alt="menu" width={32} height={32} />
+          <Image
+            src="/icon/BiMenu_shadow.png"
+            alt="menu"
+            width={32}
+            height={32}
+          />
         </button>
       </div>
 
@@ -121,7 +131,7 @@ export default function Header() {
               </div>
 
               <Link href="/food" onClick={toggleMenu} className="text-lg">
-                飲食
+                食品販売
               </Link>
               <Link href="/sale" onClick={toggleMenu} className="text-lg">
                 物品販売
@@ -166,7 +176,7 @@ export default function Header() {
                 </div>
               </div>
 
-              <div className="text-lg text-gray">飲食</div>
+              <div className="text-lg text-gray">食品販売</div>
               <div className="text-lg text-gray">物品販売</div>
               <div className="text-lg text-gray">企業ブース</div>
               <div className="text-lg text-gray">協賛企業一覧</div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue



# 概要
パンフレットの方が食品販売という名称だったため表記統一のために「飲食」を「食品販売」に変更した
/food
/food/(id)（詳細ページ）
メニューの


# 実装詳細
<!-- 具体的な開発内容を記載 -->


# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [x] foodページの表記が食品販売か
- [x] foodのidページの表記が食品販売か
- [x] ハンバーガーメニューの表記が食品販売か

# 備考
<!-- 実装していて困った箇所・質問など -->