### PR TITLE
[feat]企画と展示体験のランダム2個表示機能を作成

### DIFF
--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -2,6 +2,7 @@ import BackFrame from '@/src/components/common/back_frame';
 import Line from '@/src/components/common/line';
 import LinkButton from '@/src/components/common/link_button';
 import TextStyle from '@/src/components/common/text_style';
+import { RandomPlanItems, RandomExhExpItems} from '@/src/components/event/random_banner';
 
 export default function EventPage() {
   return (
@@ -28,7 +29,8 @@ export default function EventPage() {
             </LinkButton>
           </div>
           <div>
-            <p>ここに企画ランダム表示</p>
+            {/* 企画ランダム表示 */}
+            <RandomPlanItems />
           </div>
           <div className="flex justify-between px-8 items-center">
             <TextStyle styleType="section_title">展示・体験</TextStyle>
@@ -37,7 +39,8 @@ export default function EventPage() {
             </LinkButton>
           </div>
           <div>
-            <p>ここに展示体験ランダム表示</p>
+            {/* 展示体験ランダム表示 */}
+            <RandomExhExpItems />
           </div>
           <Line />
           <TextStyle styleType="section_title">タイムスケジュール</TextStyle>

--- a/src/components/event/random_banner.tsx
+++ b/src/components/event/random_banner.tsx
@@ -1,0 +1,72 @@
+import TextStyle from '@/src/components/common/text_style';
+import ExhExpCellContent from '@/src/components/event/exh_exp/CellContent';
+import CellContent from '@/src/components/event/plan/CellContent';
+import { getAllExhExpData } from '@/src/lib/exh_exp';
+import { getAllPlanData } from '@/src/lib/plan';
+import Link from 'next/link';
+
+function getRandomItems<T>(array: T[], count: number): T[] {
+  const shuffled = [...array].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+export function RandomPlanItems() {
+  const plans = getAllPlanData();
+  const randomPlans = getRandomItems(plans, 2);
+
+  return (
+    <div>
+      <main
+        className="grid grid-cols-2 gap-8 pb-4"
+        style={{
+          backgroundRepeat: 'no-repeat',
+          backgroundPosition: 'center',
+          backgroundSize: 'contain',
+        }}
+      >
+        {randomPlans.map((item) => (
+          <Link
+            key={item.番号}
+            href={`/event/plan/${encodeURIComponent(item.番号)}`}
+          >
+            <TextStyle styleType="body2">
+              <CellContent imageId={item.番号} title={item.企画名} />
+            </TextStyle>
+          </Link>
+        ))}
+      </main>
+    </div>
+  );
+}
+
+export function RandomExhExpItems() {
+  const exhs = getAllExhExpData();
+  const randomExhs = getRandomItems(exhs, 2);
+
+  return (
+    <div>
+      <main
+        className="grid grid-cols-2 gap-8 pb-4"
+        style={{
+          backgroundRepeat: 'no-repeat',
+          backgroundPosition: 'center',
+          backgroundSize: 'contain',
+        }}
+      >
+        {randomExhs.map((item) => (
+          <Link
+            key={item.番号}
+            href={`/event/exh_exp/${encodeURIComponent(item.番号)}`}
+          >
+            <TextStyle styleType="body2">
+              <ExhExpCellContent
+                imageId={item.番号}
+                title={item.出店タイトル}
+              />
+            </TextStyle>
+          </Link>
+        ))}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #163 
resolve #164 

# 概要
<!-- 開発内容の概要を記載 -->
企画と展示体験のランダム2個表示機能を作成した。

# 実装詳細
<!-- 具体的な開発内容を記載 -->
・`src/components/event/random_banner.tsx`ファイルを追加、ランダム表示コンポーネント作成
・`src/app/event/page.tsx`ファイルにランダム表示コンポーネントを追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->
<img width="565" height="720" alt="image" src="https://github.com/user-attachments/assets/ce49d682-ff4f-4492-a0b4-b743068bf782" />

[figmaのお手本](https://www.figma.com/design/3bcOSgtWZRNJNZj4aLuZzh/%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3Draft?node-id=541-148869&p=f&m=dev)




# テスト項目
<!-- テストしてほしい内容を記載 -->
<!-- ex) コンポーネントのデザインが崩れないか -->
<!-- ex) データが表示できてるか・反映されてるか -->
- [ ] ちゃんとランダムに表示されるか
- [ ] デザインに崩れはないか
- [ ] クリックしてイベントidページ（イベントの詳細ページ）に飛べるか

# 備考
<!-- 実装していて困った箇所・質問など -->
eventページからバナーをクリックしてidページに飛んだあと、戻るボタンを押すとeventページではなくebent/plan または event/exh_expに飛ぶが、問題ないかどうか気になる。