### PR TITLE
[fix]ゲストページ注意事項の修正

### DIFF
--- a/src/components/event/guest/guest_attentions.tsx
+++ b/src/components/event/guest/guest_attentions.tsx
@@ -14,8 +14,8 @@ const GuestAttentions = () => {
               会場での注意事項
             </TextStyle>
             <div>
-              <div className="flex justify-center text-accent items-center gap-x-2">
-                <BiCameraOff size={56} />
+              <div className="flex justify-start text-accent items-center gap-x-2">
+                <BiCameraOff size={40} />
                 <p className="font-bold">イベント中の 録音・撮影は原則禁止</p>
               </div>
               <p className="text-accent">
@@ -23,8 +23,8 @@ const GuestAttentions = () => {
               </p>
             </div>
             <div className="w-full">
-              <div className="flex justify-center text-accent items-center gap-x-2">
-                <div className="flex justify-center text-accent items-center min-w-max">
+              <div className="flex justify-start text-accent items-center gap-x-2">
+                <div className="flex justify-start text-accent items-center min-w-max">
                   <MdOutlineNoMeals size={40} />
                   <LuCupSoda size={40} />
                 </div>


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #187

# 概要
<!-- 開発内容の概要を記載 -->
ゲスト注意事項セクションのアイコン位置を左寄せに修正

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `src/components/event/guest/guest_attentions.tsx` のレイアウトを修正
- カメラアイコン（BiCameraOff）と食事・飲み物アイコン（MdOutlineNoMeals, LuCupSoda）の位置を統一
- `justify-center` を `justify-start` に変更してアイコンを左寄せに配置
- アイコンサイズを40に統一

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->


# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] ゲストページの注意事項セクションでアイコンが左寄せで表示されるか
- [ ] カメラアイコンと食事・飲み物アイコンの左端位置が揃っているか
- [ ] レスポンシブデザインが崩れていないか
- [ ] アイコンとテキストの間隔が適切に保たれているか

# 備考
<!-- 実装していて困った箇所・質問など -->
