### PR TITLE
[fix]展示体験の文字色修正

### DIFF
--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -39,7 +39,9 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
         <ReturnEventButton href="/event/exh_exp" />
         <div className="text-center">
           <TextStyle styleType="section_title">展示・体験</TextStyle>
-          <p className="text-h2 pt-2 py-4">{item.出店タイトル}</p>
+          <p className="text-h2 pt-2 py-4 text-font_main">
+            {item.出店タイトル}
+          </p>
         </div>
         <div className="pb-4 pt-4">
           <div className="w-[70%] aspect-square flex items-center justify-center relative max-w-lg mx-auto">
@@ -53,7 +55,9 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
           </div>
         </div>
 
-        <p className="text-center my-8 text-body1">{item.PR文}</p>
+        <p className="text-center my-8 text-body1 text-font_main">
+          {item.PR文}
+        </p>
 
         <div className="flex justify-center gap-4 my-8">
           {tags.map((tag, index) => (


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #185 

# 概要
<!-- 開発内容の概要を記載 -->
展示体験idページの文字色を修正（白色→黒色）

# 実装詳細
<!-- 具体的な開発内容を記載 -->
- `src/app/event/exh_exp/[id]/page.tsx` の文字色を修正
- 出店タイトル部分に `text-font_main` クラスを追加
- PR文部分に `text-font_main` クラスを追加

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 展示体験idページで出店タイトルが黒色で表示されるか
- [ ] 展示体験idページでPR文が黒色で表示されるか

# 備考
<!-- 実装していて困った箇所・質問など -->
文字色の統一性を保つため、プロジェクトで定義されている `text-font_main` クラスを使用しました。