### PR TITLE
広告カルーセル実装

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import TopAttentions from '@/src/components/top/top_attentions';
 import TopCarousel from '@/src/components/top/top_carousel';
 import Image from 'next/image';
 import TimeSchedule from '../components/common/time_schedule';
+import SponsorCarousel from '../components/common/sponser-carousel';
 // const TitleDate = '/logo/title_date.svg';
 // const TitleLogo = '/logo/title_logo.svg';
 export const runtime = 'edge';
@@ -61,6 +62,7 @@ export default function TopPage() {
           <div className="text-center">
             <TextStyle styleType="body2">Coming soon</TextStyle>
           </div>
+          <SponsorCarousel/>
         </div>
       </BackFrame>
     </div>

--- a/src/components/common/simple-carousel.tsx
+++ b/src/components/common/simple-carousel.tsx
@@ -1,0 +1,64 @@
+'use client';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
+
+interface SimpleCarouselProps {
+  children: ReactNode | ReactNode[];
+  className?: string;
+  autoSlide?: boolean;
+  autoSlideInterval?: number;
+}
+
+const SimpleCarousel: React.FC<SimpleCarouselProps> = ({
+  children,
+  className,
+  autoSlide = false,
+  autoSlideInterval = 3000,
+}) => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const childrenArray = React.Children.toArray(children);
+
+  const nextSlide = () => {
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % childrenArray.length);
+  };
+
+  const prevSlide = () => {
+    setCurrentIndex((prevIndex) =>
+      prevIndex === 0 ? childrenArray.length - 1 : prevIndex - 1
+    );
+  };
+
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: nextSlide,
+    onSwipedRight: prevSlide,
+  });
+
+  useEffect(() => {
+    if (!autoSlide) return;
+    const slideInterval = setInterval(() => {
+      nextSlide();
+    }, autoSlideInterval);
+    return () => clearInterval(slideInterval);
+  }, [currentIndex, autoSlide, autoSlideInterval]);
+
+  return (
+    <div className={`relative overflow-hidden ${className}`} {...swipeHandlers}>
+      <div
+        className="flex transition-transform duration-500"
+        style={{ transform: `translateX(-${currentIndex * 100}%)` }}
+      >
+        {childrenArray.map((child, index) => (
+          <div key={index} className="w-full flex-shrink-0 relative z-10">
+            <div className="flex items-center justify-center h-full w-full">
+              <div className="object-contain max-h-full max-w-full overflow-hidden">
+                {child}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SimpleCarousel;

--- a/src/components/common/simple-carousel.tsx
+++ b/src/components/common/simple-carousel.tsx
@@ -49,8 +49,8 @@ const SimpleCarousel: React.FC<SimpleCarouselProps> = ({
       >
         {childrenArray.map((child, index) => (
           <div key={index} className="w-full flex-shrink-0 relative z-10">
-            <div className="flex items-center justify-center h-full w-full">
-              <div className="object-contain max-h-full max-w-full overflow-hidden">
+            <div className="h-full w-full">
+              <div className="max-h-full max-w-full overflow-hidden">
                 {child}
               </div>
             </div>

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -14,7 +14,6 @@ interface SponsorCarouselProps {
 }
 
 export default function SponsorCarousel({
-  title = '協賛企業一覧',
   className = '',
   autoSlide = true,
   autoSlideInterval = 4000,
@@ -35,9 +34,9 @@ export default function SponsorCarousel({
 
   return (
     <div className={`w-full ${className}`}>
-      <h2 className="text-2xl font-bold text-center mb-6">{title}</h2>
+   
 
-      <div className="w-full max-w-5xl mx-auto mb-8">
+      <div className="w-hull">
         <SimpleCarousel autoSlide={autoSlide} autoSlideInterval={autoSlideInterval}>
           {imageSponsors.map((sponsor, index) => (
             <ImageSponsorCard key={index} sponsor={sponsor} />

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -15,7 +15,7 @@ interface SponsorCarouselProps {
 
 export default function SponsorCarousel({
   autoSlide = true,
-  autoSlideInterval = 4000,
+  autoSlideInterval = 5000,
 }: SponsorCarouselProps) {
   const [imageSponsors, setImageSponsors] = useState<SponsoringCorpolateItem[]>(
     []
@@ -52,7 +52,8 @@ export default function SponsorCarousel({
                   <ImageSponsorCard key={index} sponsor={sponsor} />
                 ))}
               </SimpleCarousel>
-              <div className="flex justify-center">
+              {/* ↓協賛ページ公開時に有効にする */}
+              {/* <div className="flex justify-center">
               <a
                 className="bg-base text-main border border-main px-12  py-4 rounded-sm text-body2 shadow_button text-center hover:bg-second hover:text-base transition-colors"
                 href="/sponsoring_corpolate"
@@ -61,7 +62,7 @@ export default function SponsorCarousel({
               >
                 ご協賛いただいた企業様＞＞
               </a>
-              </div>
+              </div> */}
             </div>
           </div>
         </div>

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getSponsoringCorpolateDataWithImages } from '@/src/lib/sponsoring_corpolate';
+import { SponsoringCorpolateItem } from '@/src/types/sponsoring_corpolate';
+import ImageSponsorCard from '@/src/components/sponsoring_corpolate/ImageSponsorCard';
+import SimpleCarousel from '@/src/components/common/simple-carousel';
+
+interface SponsorCarouselProps {
+  title?: string;
+  className?: string;
+  autoSlide?: boolean;
+  autoSlideInterval?: number;
+}
+
+export default function SponsorCarousel({
+  title = '協賛企業一覧',
+  className = '',
+  autoSlide = true,
+  autoSlideInterval = 4000,
+}: SponsorCarouselProps) {
+  const [imageSponsors, setImageSponsors] = useState<SponsoringCorpolateItem[]>([]);
+
+  useEffect(() => {
+    setImageSponsors(getSponsoringCorpolateDataWithImages());
+  }, []);
+
+  if (imageSponsors.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500 text-lg">協賛企業データを読み込み中...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`w-full ${className}`}>
+      <h2 className="text-2xl font-bold text-center mb-6">{title}</h2>
+
+      <div className="w-full max-w-5xl mx-auto mb-8">
+        <SimpleCarousel autoSlide={autoSlide} autoSlideInterval={autoSlideInterval}>
+          {imageSponsors.map((sponsor, index) => (
+            <ImageSponsorCard key={index} sponsor={sponsor} />
+          ))}
+        </SimpleCarousel>
+      </div>
+    </div>
+  );
+}

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -36,13 +36,13 @@ export default function SponsorCarousel({
   return (
     <div className="flex justify-center">
       <div
-        className={`p-0.5 w-[90%] min-w-[200px] border-2 border-second bg-base_back rounded-sm`}
+        className={`p-0.5 w-[90%] min-w-[200px] max-w-[300px] border-2 border-second bg-base_back rounded-sm`}
       >
         <div
           className="w-full border border-second rounded-sm
                   py-2"
         >
-          <div className="flex flex-colgap-4">
+          <div className="flex flex-col gap-4">
             <div className="w-hull px-2 h-auto">
               <SimpleCarousel
                 autoSlide={autoSlide}
@@ -53,16 +53,16 @@ export default function SponsorCarousel({
                 ))}
               </SimpleCarousel>
               {/* ↓協賛ページ公開時に有効にする */}
-              {/* <div className="flex justify-center">
+              <div className="flex justify-center">
               <a
-                className="bg-base text-main border border-main px-12  py-4 rounded-sm text-body2 shadow_button text-center hover:bg-second hover:text-base transition-colors"
+                className="bg-base text-body2 text-main border border-main w-full py-4 rounded-sm text-body2 shadow_button text-center hover:bg-second hover:text-base transition-colors"
                 href="/sponsoring_corpolate"
                 target="_blank"
                 rel="noopener noreferrer"
               >
                 ご協賛いただいた企業様＞＞
               </a>
-              </div> */}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -5,7 +5,6 @@ import ImageSponsorCard from '@/src/components/sponsoring_corpolate/ImageSponsor
 import { getSponsoringCorpolateDataWithImages } from '@/src/lib/sponsoring_corpolate';
 import { SponsoringCorpolateItem } from '@/src/types/sponsoring_corpolate';
 import { useEffect, useState } from 'react';
-import Frame from './frame';
 
 interface SponsorCarouselProps {
   title?: string;
@@ -35,17 +34,38 @@ export default function SponsorCarousel({
   }
 
   return (
-    <Frame>
-      <div className="w-hull px-2">
-        <SimpleCarousel
-          autoSlide={autoSlide}
-          autoSlideInterval={autoSlideInterval}
+    <div className="flex justify-center">
+      <div
+        className={`p-0.5 w-[90%] min-w-[200px] border-2 border-second bg-base_back rounded-sm`}
+      >
+        <div
+          className="w-full border border-second rounded-sm
+                  py-2"
         >
-          {imageSponsors.map((sponsor, index) => (
-            <ImageSponsorCard key={index} sponsor={sponsor} />
-          ))}
-        </SimpleCarousel>
+          <div className="flex flex-colgap-4">
+            <div className="w-hull px-2 h-auto">
+              <SimpleCarousel
+                autoSlide={autoSlide}
+                autoSlideInterval={autoSlideInterval}
+              >
+                {imageSponsors.map((sponsor, index) => (
+                  <ImageSponsorCard key={index} sponsor={sponsor} />
+                ))}
+              </SimpleCarousel>
+              <div className="flex justify-center">
+              <a
+                className="bg-base text-main border border-main px-12  py-4 rounded-sm text-body2 shadow_button text-center hover:bg-second hover:text-base transition-colors"
+                href="/sponsoring_corpolate"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ご協賛いただいた企業様＞＞
+              </a>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
-    </Frame>
+    </div>
   );
 }

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -15,7 +15,6 @@ interface SponsorCarouselProps {
 }
 
 export default function SponsorCarousel({
-  className = '',
   autoSlide = true,
   autoSlideInterval = 4000,
 }: SponsorCarouselProps) {

--- a/src/components/common/sponser-carousel.tsx
+++ b/src/components/common/sponser-carousel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import SimpleCarousel from '@/src/components/common/simple-carousel';
+import ImageSponsorCard from '@/src/components/sponsoring_corpolate/ImageSponsorCard';
 import { getSponsoringCorpolateDataWithImages } from '@/src/lib/sponsoring_corpolate';
 import { SponsoringCorpolateItem } from '@/src/types/sponsoring_corpolate';
-import ImageSponsorCard from '@/src/components/sponsoring_corpolate/ImageSponsorCard';
-import SimpleCarousel from '@/src/components/common/simple-carousel';
+import { useEffect, useState } from 'react';
+import Frame from './frame';
 
 interface SponsorCarouselProps {
   title?: string;
@@ -18,7 +19,9 @@ export default function SponsorCarousel({
   autoSlide = true,
   autoSlideInterval = 4000,
 }: SponsorCarouselProps) {
-  const [imageSponsors, setImageSponsors] = useState<SponsoringCorpolateItem[]>([]);
+  const [imageSponsors, setImageSponsors] = useState<SponsoringCorpolateItem[]>(
+    []
+  );
 
   useEffect(() => {
     setImageSponsors(getSponsoringCorpolateDataWithImages());
@@ -33,16 +36,17 @@ export default function SponsorCarousel({
   }
 
   return (
-    <div className={`w-full ${className}`}>
-   
-
-      <div className="w-hull">
-        <SimpleCarousel autoSlide={autoSlide} autoSlideInterval={autoSlideInterval}>
+    <Frame>
+      <div className="w-hull px-2">
+        <SimpleCarousel
+          autoSlide={autoSlide}
+          autoSlideInterval={autoSlideInterval}
+        >
           {imageSponsors.map((sponsor, index) => (
             <ImageSponsorCard key={index} sponsor={sponsor} />
           ))}
         </SimpleCarousel>
       </div>
-    </div>
+    </Frame>
   );
 }

--- a/src/components/sponsoring_corpolate/ImageSponsorCard.tsx
+++ b/src/components/sponsoring_corpolate/ImageSponsorCard.tsx
@@ -10,8 +10,8 @@ interface ImageSponsorCardProps {
 
 export default function ImageSponsorCard({ sponsor }: ImageSponsorCardProps) {
   const CardContent = () => (
-    <div className="bg-white border-2 border-yellow-400 p-4 text-center">
-      <h3 className="text-lg font-bold mb-4 text-[#432F2F]">
+    <div className="p-2 text-center">
+      <h3 className="body1 text-font_khaki pb-2">
         {sponsor.企業名}
       </h3>
       <div className="w-full aspect-video flex items-center justify-center relative bg-black">

--- a/src/components/sponsoring_corpolate/ImageSponsorCard.tsx
+++ b/src/components/sponsoring_corpolate/ImageSponsorCard.tsx
@@ -10,17 +10,18 @@ interface ImageSponsorCardProps {
 
 export default function ImageSponsorCard({ sponsor }: ImageSponsorCardProps) {
   const CardContent = () => (
-    <div className="p-2 text-center">
+    <div className=" p-2 text-center">
       <h3 className="body1 text-font_khaki pb-2">
         {sponsor.企業名}
       </h3>
-      <div className="w-full aspect-video flex items-center justify-center relative bg-black">
+      <div className="w-full aspect-[3/2] flex items-center justify-center relative">
         <FallbackImage
           imageDir="sponsoring_corpolate"
           imageId={sponsor.番号}
           alt={sponsor.企業名}
           fill
-          className="object-contain"
+          className="object-contain w-full h-full"
+
         />
       </div>
     </div>


### PR DESCRIPTION
<!-- 全部埋める必要はありませんが，できるだけわかりやすく書いてください -->
# 対応Issue
resolve #183

# 概要
・CarouselComponentとして広告カルーセルを実装した
・広告は8/17までに運用開始だが協賛一覧ページは９月からの運用とのことなので、ページへのボタンはコメントアウトで無効に設定した


# 実装詳細
<!-- 具体的な開発内容を記載 -->


# 画面スクリーンショット等
・ボタンコメントアウト時（9月まで）
<img width="344" height="270" alt="image" src="https://github.com/user-attachments/assets/e92d391f-a54c-4310-aae5-e0a5c5f8a6b4" />

・ボタン実装時（９月から）
<img width="350" height="309" alt="image" src="https://github.com/user-attachments/assets/d84be81b-36b4-4d52-89bf-3ac48189f88b" />



# テスト項目
- [x] データベースと見比べて正しく広告が表示されているか
- [ ] デザインが崩れていないか
- [x] 画像のリンクが有効であるか
- [x] ボタンを有効にした際にボタンが正しく動作するか

# 備考
<!-- 実装していて困った箇所・質問など -->