### PR TITLE
画像ダウンロード時の名前変更

### DIFF
--- a/scripts/download-images.mjs
+++ b/scripts/download-images.mjs
@@ -88,6 +88,16 @@ const parseTsvToJSON = (tsvText) => {
   });
 };
 
+// カテゴリ別の頭文字マッピング
+const CATEGORY_PREFIXES = {
+  exh_exp: 'E',
+  sale: 'S',
+  food: 'F',
+  corpolate_booth: 'C',
+  plan: 'P',
+  sponsoring_corpolate: 'SP',
+};
+
 // メイン処理
 async function main() {
   console.log('Starting data synchronization script...');
@@ -117,18 +127,19 @@ async function main() {
       console.log(`  Created directory: ${imageDir}`);
     }
 
+    // カテゴリの頭文字を取得
+    const prefix = CATEGORY_PREFIXES[source.name] || 'X';
+
     for (const [index, item] of items.entries()) {
       const imageUrl = item[source.image_url_column];
-      let imageId = item[source.id_column];
-
-      // 番号が欠損している場合は代替IDを生成
-      if (!imageId || imageId.trim() === '') {
-        imageId = `missing-${index}`;
-      }
 
       if (!imageUrl) continue; // 画像URLがない場合のみスキップ
 
-      console.log(`  Downloading image for item ${imageId}...`);
+      // 新しい命名規則: 頭文字 + 順番（1から開始）
+      const sequenceNumber = index + 1;
+      const newImageId = `${prefix}${sequenceNumber}`;
+
+      console.log(`  Downloading image ${sequenceNumber} as ${newImageId}...`);
 
       let success = false;
       let filename;
@@ -142,14 +153,14 @@ async function main() {
           continue;
         }
 
-        filename = `${imageId}.png`;
+        filename = `${newImageId}.png`;
         filepath = path.join(imageDir, filename);
         const downloadUrl = `https://drive.google.com/uc?export=download&id=${fileId}`;
         success = await downloadImage(downloadUrl, filepath);
       } else {
         // Firebase/Imgur URL の場合（新しい方法）
         const extension = getFileExtensionFromUrl(imageUrl);
-        filename = `${imageId}${extension}`;
+        filename = `${newImageId}${extension}`;
         filepath = path.join(imageDir, filename);
         success = await downloadImageDirect(imageUrl, filepath);
       }

--- a/src/app/event/exh_exp/[id]/page.tsx
+++ b/src/app/event/exh_exp/[id]/page.tsx
@@ -18,13 +18,20 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
   const decodedId = decodeURIComponent(params.id);
 
   let item: ExhExpItem | undefined;
+  let itemIndex = 0;
+
   if (decodedId.startsWith('missing-')) {
     // missing-${index} 形式の場合、インデックスから取得
-    const index = parseInt(decodedId.split('-')[1]);
+    itemIndex = parseInt(decodedId.split('-')[1]);
     const allData = getAllExhExpData();
-    item = allData[index];
+    item = allData[itemIndex];
   } else {
+    // 通常のIDの場合、全データから該当アイテムのインデックスを取得
+    const allData = getAllExhExpData();
     item = getExhExpDataById(decodedId);
+    if (item) {
+      itemIndex = allData.findIndex((data) => data.番号 === item?.番号);
+    }
   }
 
   if (!item) {
@@ -47,7 +54,8 @@ export default async function ExhExpDetailPage({ params }: ExhExpDetailProps) {
           <div className="w-[70%] aspect-square flex items-center justify-center relative max-w-lg mx-auto">
             <FallbackImage
               imageDir="exh_exp"
-              imageId={item.番号}
+              category="exh_exp"
+              sequenceNumber={itemIndex + 1}
               alt={item.出店タイトル || 'image'}
               fill
               className="object-contain"

--- a/src/app/event/exh_exp/page.tsx
+++ b/src/app/event/exh_exp/page.tsx
@@ -81,6 +81,13 @@ export default function ExhExpPage() {
                   {chunk.map((item, index) => {
                     const itemId =
                       item.番号 || `missing-${chunkIndex}-${index}`;
+                    // 元のデータでのインデックスを計算
+                    const originalIndex = allData.findIndex(
+                      (data) => data === item
+                    );
+                    const sequenceNumber =
+                      originalIndex >= 0 ? originalIndex + 1 : undefined;
+
                     return (
                       <div key={itemId} className="text-center">
                         <IdFrame>
@@ -93,6 +100,7 @@ export default function ExhExpPage() {
                               <CellContent
                                 imageId={item.番号}
                                 title={item.出店タイトル}
+                                sequenceNumber={sequenceNumber}
                               />
                             </TextStyle>
                           </Link>

--- a/src/app/food/[id]/page.tsx
+++ b/src/app/food/[id]/page.tsx
@@ -2,10 +2,10 @@ export const runtime = 'edge';
 import BackFrame from '@/src/components/common/back_frame';
 import DetailMap from '@/src/components/common/detail_map';
 import FallbackImage from '@/src/components/common/FallbackImage';
+import Frame from '@/src/components/common/frame';
 import Line from '@/src/components/common/line';
 import ReturnEventButton from '@/src/components/common/return_event_button';
 import TextStyle from '@/src/components/common/text_style';
-import Frame from '@/src/components/common/frame';
 import { getAllFoodData, getFoodDataById } from '@/src/lib/food';
 import { FoodItem } from '@/src/types/food';
 
@@ -19,13 +19,20 @@ export default async function FoodDetailPage({ params }: FoodDetailProps) {
   const decodedId = decodeURIComponent(params.id);
 
   let item: FoodItem | undefined;
+  let itemIndex = 0;
+
   if (decodedId.startsWith('missing-')) {
     // missing-${index} 形式の場合、インデックスから取得
-    const index = parseInt(decodedId.split('-')[1]);
+    itemIndex = parseInt(decodedId.split('-')[1]);
     const allData = getAllFoodData();
-    item = allData[index];
+    item = allData[itemIndex];
   } else {
+    // 通常のIDの場合、全データから該当アイテムのインデックスを取得
+    const allData = getAllFoodData();
     item = getFoodDataById(decodedId);
+    if (item) {
+      itemIndex = allData.findIndex((data) => data.番号 === item?.番号);
+    }
   }
 
   if (!item) {
@@ -46,7 +53,8 @@ export default async function FoodDetailPage({ params }: FoodDetailProps) {
           <div className="w-[70%] aspect-square flex items-center justify-center relative max-w-lg mx-auto">
             <FallbackImage
               imageDir="food"
-              imageId={item.番号}
+              category="food"
+              sequenceNumber={itemIndex + 1}
               alt={item.出店タイトル || 'image'}
               fill
               className="object-contain"
@@ -58,7 +66,9 @@ export default async function FoodDetailPage({ params }: FoodDetailProps) {
 
         {item.メニュー && (
           <Frame>
-            <TextStyle styleType="section_title" className="text-center">おしながき</TextStyle>
+            <TextStyle styleType="section_title" className="text-center">
+              おしながき
+            </TextStyle>
             <p className="text-body1 mt-2">{item.メニュー}</p>
           </Frame>
         )}

--- a/src/app/food/page.tsx
+++ b/src/app/food/page.tsx
@@ -96,6 +96,13 @@ export default function FoodPage() {
                     {chunk.map((item, index) => {
                       const itemId =
                         item.番号 || `missing-${chunkIndex}-${index}`;
+                      // 元のデータでのインデックスを計算
+                      const originalIndex = allData.findIndex(
+                        (data) => data === item
+                      );
+                      const sequenceNumber =
+                        originalIndex >= 0 ? originalIndex + 1 : undefined;
+
                       return (
                         <div key={itemId} className="text-center">
                           <IdFrame>
@@ -103,6 +110,7 @@ export default function FoodPage() {
                               <CellContent
                                 imageId={item.番号}
                                 title={item.出店タイトル}
+                                sequenceNumber={sequenceNumber}
                               />
                             </Link>
                           </IdFrame>

--- a/src/app/sale/[id]/page.tsx
+++ b/src/app/sale/[id]/page.tsx
@@ -18,13 +18,20 @@ export default async function SaleDetailPage({ params }: SaleDetailProps) {
   const decodedId = decodeURIComponent(params.id);
 
   let item: SaleItem | undefined;
+  let itemIndex = 0;
+
   if (decodedId.startsWith('missing-')) {
     // missing-${index} 形式の場合、インデックスから取得
-    const index = parseInt(decodedId.split('-')[1]);
+    itemIndex = parseInt(decodedId.split('-')[1]);
     const allData = getAllSaleData();
-    item = allData[index];
+    item = allData[itemIndex];
   } else {
+    // 通常のIDの場合、全データから該当アイテムのインデックスを取得
+    const allData = getAllSaleData();
     item = getSaleDataById(decodedId);
+    if (item) {
+      itemIndex = allData.findIndex((data) => data.番号 === item?.番号);
+    }
   }
 
   if (!item) {
@@ -45,7 +52,8 @@ export default async function SaleDetailPage({ params }: SaleDetailProps) {
           <div className="w-[70%] aspect-square flex items-center justify-center relative max-w-lg mx-auto">
             <FallbackImage
               imageDir="sale"
-              imageId={item.番号}
+              category="sale"
+              sequenceNumber={itemIndex + 1}
               alt={item.出店タイトル || 'image'}
               fill
               className="object-contain"

--- a/src/app/sale/page.tsx
+++ b/src/app/sale/page.tsx
@@ -1,25 +1,19 @@
 'use client';
 
 import BackFrame from '@/src/components/common/back_frame';
+import IdFrame from '@/src/components/common/id_frame';
 import Line from '@/src/components/common/line';
+import SponsorCarousel from '@/src/components/common/sponser-carousel'; // 追加
 import Tag from '@/src/components/common/tag';
 import TagModal from '@/src/components/common/tag_modal';
 import TextStyle from '@/src/components/common/text_style';
 import CellContent from '@/src/components/sale/CellContent';
-import SponsorCarousel from '@/src/components/common/sponser-carousel'; // 追加
 import { getAllSaleData } from '@/src/lib/sale';
 import { SaleItem } from '@/src/types/sale';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import IdFrame from '@/src/components/common/id_frame';
 
-const allTags = [
-  '子供向け',
-  '技大グッズ',
-  '学生出店',
-  '企業出店',
-  'フリマ',
-];
+const allTags = ['子供向け', '技大グッズ', '学生出店', '企業出店', 'フリマ'];
 
 // 🔧 配列をチャンクに分割する関数
 function chunkArray<T>(array: T[], size: number): T[][] {
@@ -82,7 +76,15 @@ export default function SalePage() {
               {chunkArray(filteredData, 8).map((chunk, chunkIndex) => (
                 <div key={`chunk-${chunkIndex}`} className="contents">
                   {chunk.map((item, index) => {
-                    const itemId = item.番号 || `missing-${chunkIndex}-${index}`;
+                    const itemId =
+                      item.番号 || `missing-${chunkIndex}-${index}`;
+                    // 元のデータでのインデックスを計算
+                    const originalIndex = allData.findIndex(
+                      (data) => data === item
+                    );
+                    const sequenceNumber =
+                      originalIndex >= 0 ? originalIndex + 1 : undefined;
+
                     return (
                       <div key={itemId} className="text-center">
                         <IdFrame>
@@ -90,6 +92,7 @@ export default function SalePage() {
                             <CellContent
                               imageId={item.番号}
                               title={item.出店タイトル}
+                              sequenceNumber={sequenceNumber}
                             />
                           </Link>
                         </IdFrame>

--- a/src/components/common/FallbackImage.tsx
+++ b/src/components/common/FallbackImage.tsx
@@ -10,6 +10,9 @@ import { useState } from 'react';
 interface FallbackImageProps {
   imageDir: string;
   imageId?: string;
+  // 新しい命名規則用のプロパティ
+  category?: string;
+  sequenceNumber?: number;
   alt: string;
   fill?: boolean;
   width?: number;
@@ -18,9 +21,21 @@ interface FallbackImageProps {
   unoptimized?: boolean;
 }
 
+// カテゴリ別の頭文字マッピング
+const CATEGORY_PREFIXES: Record<string, string> = {
+  exh_exp: 'E',
+  sale: 'S',
+  food: 'F',
+  corpolate_booth: 'C',
+  plan: 'P',
+  sponsoring_corpolate: 'SP',
+};
+
 export default function FallbackImage({
   imageDir,
   imageId,
+  category,
+  sequenceNumber,
   alt,
   fill,
   width,
@@ -31,7 +46,17 @@ export default function FallbackImage({
   const [currentSrcIndex, setCurrentSrcIndex] = useState(0);
   const [hasError, setHasError] = useState(false);
 
-  if (!imageId) {
+  // 新しい命名規則を使用するかどうかを判定
+  const useNewNaming = category && sequenceNumber !== undefined;
+
+  // 実際に使用するimageIdを決定
+  let actualImageId = imageId;
+  if (useNewNaming) {
+    const prefix = CATEGORY_PREFIXES[category] || 'X';
+    actualImageId = `${prefix}${sequenceNumber}`;
+  }
+
+  if (!actualImageId) {
     // imageIdがない場合のフォールバック
     return (
       <div className="w-full h-full flex flex-col items-center justify-center text-white">
@@ -47,9 +72,9 @@ export default function FallbackImage({
     );
   }
 
-  const fallbacks = generateImageFallbacks(imageDir, imageId);
+  const fallbacks = generateImageFallbacks(imageDir, actualImageId);
   const currentSrc =
-    fallbacks[currentSrcIndex] || getInitialImageSrc(imageDir, imageId);
+    fallbacks[currentSrcIndex] || getInitialImageSrc(imageDir, actualImageId);
 
   const handleError = () => {
     if (currentSrcIndex < fallbacks.length - 1) {

--- a/src/components/event/exh_exp/CellContent.tsx
+++ b/src/components/event/exh_exp/CellContent.tsx
@@ -5,15 +5,22 @@ import FallbackImage from '@/src/components/common/FallbackImage';
 interface CellContentProps {
   imageId?: string;
   title?: string;
+  sequenceNumber?: number;
 }
 
-export default function CellContent({ imageId, title }: CellContentProps) {
+export default function CellContent({
+  imageId,
+  title,
+  sequenceNumber,
+}: CellContentProps) {
   return (
     <div className="flex flex-col items-center p-4">
       <div className="w-2/4 mx-auto aspect-square flex items-center justify-center relative">
         <FallbackImage
           imageDir="exh_exp"
           imageId={imageId}
+          category="exh_exp"
+          sequenceNumber={sequenceNumber}
           alt={title || 'image'}
           fill
           className="object-contain"

--- a/src/components/food/CellContent.tsx
+++ b/src/components/food/CellContent.tsx
@@ -5,21 +5,28 @@ import FallbackImage from '@/src/components/common/FallbackImage';
 interface CellContentProps {
   imageId?: string;
   title?: string;
+  sequenceNumber?: number;
 }
 
-export default function CellContent({ imageId, title }: CellContentProps) {
+export default function CellContent({
+  imageId,
+  title,
+  sequenceNumber,
+}: CellContentProps) {
   return (
     <div className="flex flex-col items-center p-4">
       <div className="w-2/4 mx-auto aspect-square flex items-center justify-center relative">
         <FallbackImage
           imageDir="food"
           imageId={imageId}
+          category="food"
+          sequenceNumber={sequenceNumber}
           alt={title || 'image'}
           fill
           className="object-contain"
         />
       </div>
-      <p className="mt-2">{title || '飲食店名'}</p>
+      <p className="mt-2">{title || '食品販売名'}</p>
     </div>
   );
 }

--- a/src/components/sale/CellContent.tsx
+++ b/src/components/sale/CellContent.tsx
@@ -5,21 +5,28 @@ import FallbackImage from '@/src/components/common/FallbackImage';
 interface CellContentProps {
   imageId?: string;
   title?: string;
+  sequenceNumber?: number;
 }
 
-export default function CellContent({ imageId, title }: CellContentProps) {
+export default function CellContent({
+  imageId,
+  title,
+  sequenceNumber,
+}: CellContentProps) {
   return (
     <div className="flex flex-col items-center p-4">
       <div className="w-2/4 mx-auto aspect-square flex items-center justify-center relative">
         <FallbackImage
           imageDir="sale"
           imageId={imageId}
+          category="sale"
+          sequenceNumber={sequenceNumber}
           alt={title || 'image'}
           fill
           className="object-contain"
         />
       </div>
-      <p className="mt-2">{title || '物品名'}</p>
+      <p className="mt-2">{title || '物品販売名'}</p>
     </div>
   );
 }


### PR DESCRIPTION
# 対応Issue
<!-- 対応したIssue番号を記載 -->
resolve #200 

# 概要
<!-- 開発内容の概要を記載 -->
画像ファイル名に日本語文字や空白文字が含まれることで画像が正常に表示されない問題を解決するため、新しい画像ファイル命名規則を実装しました。「カテゴリ頭文字 + 順番」の形式（例：E1.jpg, F2.png）で英数字のみのファイル名を生成し、安全で管理しやすい画像システムを構築しました。

# 実装詳細
<!-- 具体的な開発内容を記載 -->

## ダウンロードスクリプトの修正 (`scripts/download-images.mjs`)
- カテゴリ別頭文字マッピングを追加：
  - `exh_exp` (展示・体験) → `E`
  - `food` (食品販売) → `F`
  - `sale` (物品販売) → `S`
  - `corpolate_booth` (企業ブース) → `C`
  - `plan` (企画) → `P`
  - `sponsoring_corpolate` (協賛企業) → `SP`
- スプレッドシートの行順に基づいて連番でファイル名を生成

# 画面スクリーンショット等
<!-- URLとともに貼る（なければ空欄でよい） -->

# テスト項目
<!-- テストしてほしい内容を記載 -->
- [ ] 新しい画像ダウンロードスクリプトが正常に動作し、英数字のみのファイル名で保存されるか
- [ ] 展示・体験ページで画像が正常に表示されるか（一覧・詳細両方）
- [ ] 食品販売ページで画像が正常に表示されるか（一覧・詳細両方）
- [ ] 物品販売ページで画像が正常に表示されるか（一覧・詳細両方）
- [ ] タグフィルタリング機能使用時も画像が正常に表示されるか
- [ ] 既存の画像ID形式でも引き続き表示されるか（後方互換性）
- [ ] 画像が見つからない場合のフォールバック表示が正常に動作するか

# 備考
<!-- 実装していて困った箇所・質問など -->
